### PR TITLE
Fix: is_simple_quad for triangles

### DIFF
--- a/similaritymeasures/similaritymeasures.py
+++ b/similaritymeasures/similaritymeasures.py
@@ -89,16 +89,13 @@ def is_simple_quad(ab, bc, cd, da):
     temp2 = np.cross(cd, da)
     temp3 = np.cross(da, ab)
     cross = np.array([temp0, temp1, temp2, temp3])
-    #   See that cross products are greater than or equal to zero
-    crossTF = cross >= 0
-    #   if the cross products are majority false, re compute the cross products
-    #   Because they don't necessarily need to lie in the same 'Z' direction
-    if sum(crossTF) <= 1:
+    #   See that majority of cross products is non-positive or non-negative
+    #   They don't necessarily need to lie in the same 'Z' direction
+    if sum(cross > 0) < sum(cross < 0):
         crossTF = cross <= 0
-    if sum(crossTF) > 2:
-        return True
     else:
-        return False
+        crossTF = cross >= 0
+    return sum(crossTF) > 2
 
 
 def makeQuad(x, y):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -161,6 +161,26 @@ class TestEverything(unittest.TestCase):
         quad = similaritymeasures.is_simple_quad(AB, BC, CD, DA)
         self.assertTrue(quad)
 
+    def test_simple_triangle_pos(self):
+        x = [0, 1, 1, 0]
+        y = [0, 0, 1, 0]
+        AB = [x[1]-x[0], y[1]-y[0]]
+        BC = [x[2]-x[1], y[2]-y[1]]
+        CD = [x[3]-x[2], y[3]-y[2]]
+        DA = [x[0]-x[3], y[0]-y[3]]
+        quad = similaritymeasures.is_simple_quad(AB, BC, CD, DA)
+        self.assertTrue(quad)
+
+    def test_simple_triangle_neg(self):
+        x = [0, 1, 1, 0]
+        y = [0, 1, 0, 0]
+        AB = [x[1]-x[0], y[1]-y[0]]
+        BC = [x[2]-x[1], y[2]-y[1]]
+        CD = [x[3]-x[2], y[3]-y[2]]
+        DA = [x[0]-x[3], y[0]-y[3]]
+        quad = similaritymeasures.is_simple_quad(AB, BC, CD, DA)
+        self.assertTrue(quad)
+
     def test_random_dtw(self):
         r, d = similaritymeasures.dtw(curve_a_rand, curve_b_rand)
         path = similaritymeasures.dtw_path(d)


### PR DESCRIPTION
# Problem
I discovered that the `area_between_two_curves` function is not symmetrical and could even find simple examples where the calculation is obviously wrong, e.g.
```
p = np.array([[0, 1, 2], [0, 1, 2]]).T
q = np.array([[0, 1, 2], [0, 0, 2]]).T
area_between_two_curves(p, q)  # Output: 0.0
area_between_two_curves(q, p)  # Output: 1.0
```
It turned out for triangles, i.e. having one vertex twice, the `is_simple_quad` function is False in case they are in clockwise order.

# Changes
- fixed check for negativity of cross products
- added tests for triangles

# What to look for
- The logic is still correct and makes sense
  - One could argue `is_simple_quad` does not need to work for triangles. But the change has no effect on quadrilaterals and for what it's used in this package it makes sense to correctly consider triangles.