### PR TITLE
Feature/cython 3 0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython>=3.0.3"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@
 import io
 from distutils.core import setup
 
+from Cython.Build import cythonize
+
 # load the version from version.py
 version = {}
 with open("similaritymeasures/version.py") as fp:
@@ -12,7 +14,8 @@ setup(
     version=version["__version__"],
     author='Charles Jekel',
     author_email='cjekel@gmail.com',
-    packages=['similaritymeasures'],
+    #packages=['similaritymeasures'],
+    ext_modules=cythonize('similaritymeasures/similaritymeasures.py', language='c++'),
     url='https://github.com/cjekel/similarity_measures',
     license='MIT License',
     description='Quantify the difference between two arbitrary curves in space',  # noqa E501
@@ -22,5 +25,7 @@ setup(
     install_requires=[
         "numpy >= 1.14.0",
         "scipy >= 0.19.0",
+        "cython >= 3.0.3",
+        "Cython"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,32 @@
 import io
 from distutils.core import setup
 
-from Cython.Build import cythonize
+# deciding to use cython or not based on its successful import
+USE_CYTHON : bool = True
+try:
+    from Cython.Build import cythonize
+except ModuleNotFoundError:
+    print('unable to retrieve cython, will resort to pure python installation')
+    USE_CYTHON = False
 
 # load the version from version.py
 version = {}
 with open("similaritymeasures/version.py") as fp:
     exec(fp.read(), version)
 
+# based on the option of using cython or not the ext_modules variable is set
+if USE_CYTHON:
+    ext_modules = cythonize('similaritymeasures/similaritymeasures.py', language='c++')
+else:
+    ext_modules = []
+
 setup(
     name='similaritymeasures',
     version=version["__version__"],
     author='Charles Jekel',
     author_email='cjekel@gmail.com',
-    #packages=['similaritymeasures'],
-    ext_modules=cythonize('similaritymeasures/similaritymeasures.py', language='c++'),
+    packages=['similaritymeasures'],
+    ext_modules=ext_modules,
     url='https://github.com/cjekel/similarity_measures',
     license='MIT License',
     description='Quantify the difference between two arbitrary curves in space',  # noqa E501
@@ -25,7 +37,6 @@ setup(
     install_requires=[
         "numpy >= 1.14.0",
         "scipy >= 0.19.0",
-        "cython >= 3.0.3",
-        "Cython"
+        "cython >= 3.0.3"
     ],
 )

--- a/similaritymeasures/similaritymeasures.py
+++ b/similaritymeasures/similaritymeasures.py
@@ -26,6 +26,8 @@ import cython
 # SOFTWARE.
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def poly_area(x, y):
     r"""
     A function that computes the polygonal area via the shoelace formula.
@@ -59,6 +61,8 @@ def poly_area(x, y):
     return 0.5*np.abs(np.dot(x, np.roll(y, 1))-np.dot(y, np.roll(x, 1)))
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def is_simple_quad(ab, bc, cd, da):
     r"""
     Returns True if a quadrilateral is simple
@@ -100,6 +104,8 @@ def is_simple_quad(ab, bc, cd, da):
     return sum(crossTF) > 2
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def makeQuad(x, y):
     r"""
     Calculate the area from the x and y locations of a quadrilateral
@@ -167,6 +173,8 @@ def makeQuad(x, y):
     return area
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def get_arc_length(dataset):
     r"""
     Obtain arc length distances between every point in 2-D space
@@ -205,6 +213,8 @@ def get_arc_length(dataset):
     return arcLength, arcLengths
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def area_between_two_curves(exp_data, num_data):
     r"""
     Calculates the area between two curves.
@@ -254,6 +264,9 @@ def area_between_two_curves(exp_data, num_data):
     #
     # then you can calculate the area as
     # area = area_between_two_curves(exp_data, num_data)
+    i = cython.declare(cython.int)
+    n_exp = cython.declare(cython.int)
+    n_num = cython.declare(cython.int)
 
     n_exp = len(exp_data)
     n_num = len(num_data)
@@ -302,6 +315,8 @@ def area_between_two_curves(exp_data, num_data):
     return np.sum(area)
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def get_length(x, y, norm_seg_length=True):
     r"""
     Compute arc lengths of an x y curve.
@@ -333,6 +348,8 @@ def get_length(x, y, norm_seg_length=True):
     >>> le, le_total, le_cum = get_length(x, y)
 
     """
+    i = cython.declare(cython.int)
+    n = cython.declare(cython.int)
     n = len(x)
 
     if norm_seg_length:
@@ -359,6 +376,8 @@ def get_length(x, y, norm_seg_length=True):
     return le, np.sum(le), l_sum
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def curve_length_measure(exp_data, num_data):
     r"""
     Compute the curve length based distance between two curves.
@@ -432,6 +451,8 @@ def curve_length_measure(exp_data, num_data):
     return np.sqrt(np.sum(r_sq))
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def frechet_dist(exp_data, num_data, p=2):
     r"""
     Compute the discrete Frechet distance
@@ -513,6 +534,8 @@ def frechet_dist(exp_data, num_data, p=2):
     return ca[n-1, m-1]
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def normalizeTwoCurves(x, y, w, z):
     """
     Normalize two curves for PCM method.
@@ -567,6 +590,8 @@ def normalizeTwoCurves(x, y, w, z):
     return xi, eta, xiP, etaP
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def pcm(exp_data, num_data, norm_seg_length=False):
     """
     Compute the Partial Curve Mapping area.
@@ -683,6 +708,8 @@ def pcm(exp_data, num_data, norm_seg_length=False):
     return np.min(pcm_dists)
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def dtw(exp_data, num_data, metric='euclidean', **kwargs):
     r"""
     Compute the Dynamic Time Warping distance.
@@ -788,6 +815,8 @@ def dtw(exp_data, num_data, metric='euclidean', **kwargs):
     >>> r, d = dtw(exp_data, num_data, metric='cityblock')
 
     """
+    i = cython.declare(cython.int)
+    j = cython.declare(cython.int)
     c = distance.cdist(exp_data, num_data, metric=metric, **kwargs)
 
     d = np.zeros(c.shape)
@@ -803,6 +832,8 @@ def dtw(exp_data, num_data, metric='euclidean', **kwargs):
     return d[-1, -1], d
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def dtw_path(d):
     r"""
     Calculates the optimal DTW path from a given DTW cumulative distance
@@ -867,6 +898,8 @@ def dtw_path(d):
     >>> plt.show()
 
     """
+    i = cython.declare(cython.int)
+    j = cython.declare(cython.int)
     path = []
     i, j = d.shape
     i = i - 1
@@ -894,6 +927,8 @@ def dtw_path(d):
     return path[::-1]
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def mae(exp_data, num_data):
     """
     Compute the Mean Absolute Error (MAE).
@@ -919,6 +954,8 @@ def mae(exp_data, num_data):
     return np.mean(c)
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def mse(exp_data, num_data):
     """
     Compute the Mean Squared Error (MAE).

--- a/similaritymeasures/similaritymeasures.py
+++ b/similaritymeasures/similaritymeasures.py
@@ -1,6 +1,8 @@
 from __future__ import division
 import numpy as np
 from scipy.spatial import distance
+
+import cython
 # MIT License
 #
 # Copyright (c) 2018,2019 Charles Jekel
@@ -490,6 +492,10 @@ def frechet_dist(exp_data, num_data, p=2):
     >>> df = frechet_dist(exp_data, num_data)
 
     """
+    i = cython.declare(cython.int)
+    j = cython.declare(cython.int)
+    n = cython.declare(cython.int)
+    m = cython.declare(cython.int)
     n = len(exp_data)
     m = len(num_data)
     c = distance.cdist(exp_data, num_data, metric='minkowski', p=p)


### PR DESCRIPTION
This PR proposes a version I tried on my system in order to allow for cythonization of the codebase.

In cython 3.0 the are [several functionalities working in pure python mode](https://cython.readthedocs.io/en/latest/src/tutorial/pure.html), basically allowing some legal python lines to be used to enable a better cythonization (such as `i = cython.declare(cython.int)` to indicate that i shall be transpiled to a C integer).

I added a `pyproject.toml` to let the build system temporarily install cython during the package build.

I also modified the `setup.py` file to import the cython build in a `try` statement. I tried with a boolean actually overwritten to false and that led to a normal installation.

An idea that I'm having is that it would be possible to add a function in the package to indicate whether or not the package being used is cythonized or not (I think cython already provides a native functionality to check that).

I then just declared some variables to be integers, and I ran some benchmarks (the code I used can be found in my repo [benchmark_similarity_measures](https://github.com/nucccc/benchmark_similarity_measures), which installs first one library and then the other to run the benchmarks).

The results on my machine with python 3.11 are recapped in this image, with the improvement being in %:

![cython_improv](https://github.com/cjekel/similarity_measures/assets/44038808/e4b7d170-541b-4ef6-9489-4b1253f93d93)

with numbers coming from the following csv

```
benchmark_name,master_avg,cython_avg,improv
area_between_two_curves_c1_c2,1.7039237545600463,1.6884736603800048,0.9067362397345489
frechet_c5_c6,2.0500493293800175,1.5103637769600209,26.325491035047925
area_between_two_curves_c5_c6,0.47237960685998587,0.47055805053996663,0.3856128193440721
dtw_c1_c2,0.9581847325999843,0.7472904101000131,22.009776958950333
frechet_c1_c2,1.0203404406200298,0.7517932900799679,26.319367521772836
curve_length_measure_c1_c2,0.051991073359977234,0.05167398480002703,0.6098903897496746
dtw_c5_c6,1.958265644539997,1.570278274120028,19.812805862256162
pcm_c1_c2,0.05582267186003264,0.05474561917999381,1.9294180019533789
```

Not all functions showcase a huge performance improvement, while previous benchmarks showcased a 40% performance improvement for frechet distance, which now decreased to 25%.

Probably that is because my previous benchmarks were executed against python 3.10, while python 3.11 greatly improved execution speed of native python code.

I hope this can be of interest.