### PR TITLE
Making is_simple_quad robust to numpy > 2.0

### DIFF
--- a/similaritymeasures/similaritymeasures.py
+++ b/similaritymeasures/similaritymeasures.py
@@ -57,7 +57,7 @@ def poly_area(x, y):
     return 0.5*np.abs(np.dot(x, np.roll(y, 1))-np.dot(y, np.roll(x, 1)))
 
 
-def is_simple_quad(ab, bc, cd, da):
+def is_simple_quad(ab, bc, cd, da) -> bool:
     r"""
     Returns True if a quadrilateral is simple
 
@@ -95,7 +95,7 @@ def is_simple_quad(ab, bc, cd, da):
         crossTF = cross <= 0
     else:
         crossTF = cross >= 0
-    return sum(crossTF) > 2
+    return bool(sum(crossTF) > 2)
 
 
 def makeQuad(x, y):


### PR DESCRIPTION
This PR makes the return statement of `is_simple_quad` more predictable by imposing an explicit `bool` casting.

This is done in order to prevent a value of numpy class type to be returned instead of a primitive `bool` type.